### PR TITLE
AWS Usage Instructions

### DIFF
--- a/AWSUsageInstructions.txt
+++ b/AWSUsageInstructions.txt
@@ -1,0 +1,156 @@
+The steps to set up an EC2 instance and deploy Aeron Cluster to it:
+
+1. Create and launch an EC2 instance.
+2. Install Docker on the EC2 instance.
+3. Configure EC2 Instance to be able to access ECR.
+4. Create a Docker Compose configuration.
+5. Run Aeron Cluster.
+
+
+1. Create and launch EC2 instance
+
+Please check out the AWS Documentation for general instructions on how to set up an EC2 instance.
+For this exercise, please select the following options:
+
+Application and OS Images (Amazon Machine Image): Linux Ubuntu Server 22.04 64-bit image
+Instance type: t2.micro
+Key pair (login): create a new key pair, see Documentation
+Network settings: leave as default
+Configure storage: leave as default
+Connect to your EC2 instance.
+
+
+2. Install Docker on EC2 instance
+
+Install the most recent Docker Engine package on your EC2 instance.
+
+$ curl -fsSL https://get.docker.com -o get-docker.sh
+$ sh get-docker.sh
+
+Start the Docker service.
+
+sudo service docker start
+
+Add the ubuntu user (or, the user you are using to connect to your EC2 instance) to the docker group so you can execute Docker commands without using sudo
+
+sudo usermod -a -G docker ubuntu
+
+Test Docker installation
+
+docker run hello-world
+
+
+3. Configure EC2 Instance to be able to access ECR
+
+3a. Attach IAM Role that allows read-only access to ECR
+
+Create a new AWS role either based on the pre-defined AmazonEC2ContainerRegistryReadOnly or one with the policy as below and attach to your EC2 instance
+
+{
+    "Version": "2023-05-05",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:DescribeImages",
+                "ecr:GetAuthorizationToken",
+                "ecr:ListImages"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+
+3b. Install Amazon ECR Credential Helper
+
+Unfortunately, Docker CLI does not support standard AWS authentication methods. Installing the Amazon ECR Credential Helper on the EC2 instance will allow pulling images from ECR without the need to use docker login:
+
+sudo apt install amazon-ecr-credential-helper
+
+Then set the contents of your ~/.docker/config.json file to be:
+
+{
+  "credsStore": "ecr-login"
+}
+
+
+
+4. Create Docker Compose configuration
+
+Create a file named docker-compose.yaml with the content as below
+
+version: '3.8'
+ 
+name: aeron
+ 
+services:
+  node0:
+    image: 934397558437.dkr.ecr.us-east-1.amazonaws.com/adaptive/aeron-premium:cluster-sample-v0.1.0-git7e38381
+    build:
+      context: cluster
+    hostname: cluster0
+    shm_size: '1gb'
+    networks:
+      internal_bus:
+        ipv4_address: 172.16.202.2
+    environment:
+      - CLUSTER_ADDRESSES=172.16.202.2,172.16.202.3,172.16.202.4
+      - CLUSTER_NODE=0
+      - CLUSTER_PORT_BASE=9000
+  node1:
+    image: 934397558437.dkr.ecr.us-east-1.amazonaws.com/adaptive/aeron-premium:cluster-sample-v0.1.0-git7e38381
+    build:
+      context: cluster
+    hostname: cluster1
+    shm_size: '1gb'
+    networks:
+      internal_bus:
+        ipv4_address: 172.16.202.3
+    environment:
+      - CLUSTER_ADDRESSES=172.16.202.2,172.16.202.3,172.16.202.4
+      - CLUSTER_NODE=1
+      - CLUSTER_PORT_BASE=9000
+  node2:
+    image: 934397558437.dkr.ecr.us-east-1.amazonaws.com/adaptive/aeron-premium:cluster-sample-v0.1.0-git7e38381
+    build:
+      context: cluster
+    hostname: cluster2
+    shm_size: '1gb'
+    networks:
+      internal_bus:
+        ipv4_address: 172.16.202.4
+    environment:
+      - CLUSTER_ADDRESSES=172.16.202.2,172.16.202.3,172.16.202.4
+      - CLUSTER_NODE=2
+      - CLUSTER_PORT_BASE=9000
+ 
+networks:
+  internal_bus:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.enable_icc: 'true'
+      com.docker.network.driver.mtu: 9000
+      com.docker.network.enable_ipv6: 'false'
+    ipam:
+      driver: default
+      config:
+        - subnet: "172.16.202.0/24"
+		
+
+
+
+5. Running Aeron Cluster
+
+Start the Aeron Cluster
+
+docker compose up -d
+
+Find the leader
+
+docker compose logs | grep LEADER
+
+Stop the cluster
+
+docker compose down


### PR DESCRIPTION
I've created a file containing the usage instructions for AWS Marketplace to allow Aeron Premium subscribers to deploy Aeron Premium. Can this be made displayed on this site?
[aeron-aws.txt](https://github.com/AdaptiveConsulting/aeron-io-samples/files/11558869/aeron-aws.txt)
