### PR TITLE
Cluster Standby

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+val useStandby: String by project
+
 plugins {
     java
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -86,6 +86,20 @@ services:
       - CLUSTER_ADDRESSES=172.16.202.2,172.16.202.3,172.16.202.4
       - CLUSTER_PORT_BASE=9000
       - BACKUP_HOST=172.16.202.20
+  standby:
+    profiles: ["standby"]
+    build:
+      context: ../standby
+    hostname: backup
+    shm_size: '1gb'
+    networks:
+      internal_bus:
+        ipv4_address: 172.16.202.30
+    environment:
+      - CLUSTER_ADDRESSES=172.16.202.2,172.16.202.3,172.16.202.4
+      - CLUSTER_PORT_BASE=9000
+      - STANDBY_HOST=172.16.202.30
+      - CLUSTER_NODE=4
 
 networks:
   internal_bus:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ jlineVersion = "3.23.0"
 picoJlineVersion = "4.7.4"
 mockitoVersion = "5.4.0"
 junitPlatformLauncherVersion = "1.10.0"
+aeronClusterStandbyVersion = "1.42.0-SNAPSHOT"
 
 [libraries]
 aeron = { group = "io.aeron", name = "aeron-all", version.ref = "aeronVersion" }
@@ -27,6 +28,7 @@ mockito-junit = { group = "org.mockito", name="mockito-junit-jupiter", version.r
 jline = { group = "org.jline", name = "jline", version.ref = "jlineVersion" }
 picoJline = { group = "info.picocli", name = "picocli-shell-jline3", version.ref = "picoJlineVersion" }
 junitPlatformLauncher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitPlatformLauncherVersion" }
+clusterStandby = { group = "io.aeron", name = "aeron-cluster-standby", version.ref = "aeronClusterStandbyVersion" }
 
 [bundles]
 testing = ["junitPlatformLauncher", "jupiterApi", "jupiterEngine", "mockito-core", "mockito-junit"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,10 +24,10 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
-val useStandby = true
-
 rootProject.name = "aeron-io-samples"
 include("cluster", "cluster-protocol", "admin", "backup")
-if (useStandby) {
+
+val standby: String? by settings
+if (true == standby?.toBoolean()) {
     include("standby")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,5 +24,10 @@ plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
+val useStandby = true
+
 rootProject.name = "aeron-io-samples"
 include("cluster", "cluster-protocol", "admin", "backup")
+if (useStandby) {
+    include("standby")
+}

--- a/standby/Dockerfile
+++ b/standby/Dockerfile
@@ -1,0 +1,15 @@
+ARG REPO_NAME=docker.io/
+ARG IMAGE_NAME=azul/zulu-openjdk-debian
+ARG IMAGE_TAG=17
+FROM ${REPO_NAME}${IMAGE_NAME}:${IMAGE_TAG}
+
+SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
+
+COPY --chmod=755 setup-docker.sh /root/dockerbuild/setup-docker.sh
+COPY --chmod=755 setup-docker.sh /root/aeron/
+RUN /root/dockerbuild/setup-docker.sh && rm --recursive --force "/root/dockerbuild"
+
+WORKDIR /root/jar/
+COPY --chmod=755 /build/libs/standby-uber.jar /root/jar/standby-uber.jar
+COPY --chmod=755 entrypoint.sh /root/jar/entrypoint.sh
+ENTRYPOINT ["/root/jar/entrypoint.sh"]

--- a/standby/build.gradle.kts
+++ b/standby/build.gradle.kts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Adaptive Financial Consulting
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("java-application-conventions")
+}
+
+dependencies {
+    implementation(libs.agrona)
+    implementation(libs.aeron)
+    implementation(libs.clusterStandby)
+    implementation(libs.slf4j)
+    implementation(libs.logback)
+    implementation(project(":cluster"))
+    testImplementation(libs.bundles.testing)
+}
+
+tasks {
+    task("runClusterStandby", JavaExec::class) {
+        group = "run"
+        classpath = sourceSets.main.get().runtimeClasspath
+        mainClass.set("io.aeron.samples.ClusterStandbyApp")
+        jvmArgs("--add-opens=java.base/sun.nio.ch=ALL-UNNAMED")
+    }
+
+    task ("uberJar", Jar::class) {
+        group = "uber"
+        manifest {
+            attributes["Main-Class"]="io.aeron.samples.ClusterStandbyApp"
+            attributes["Add-Opens"]="java.base/sun.nio.ch"
+        }
+        archiveClassifier.set("uber")
+        from(sourceSets.main.get().output)
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        dependsOn(configurations.runtimeClasspath)
+        from({
+            configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
+        })
+    }
+}

--- a/standby/entrypoint.sh
+++ b/standby/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -Djava.net.preferIPv4Stack=true -Daeron.ipc.mtu.length=8k "$@" -jar /root/jar/standby-uber.jar

--- a/standby/readme.md
+++ b/standby/readme.md
@@ -1,0 +1,19 @@
+# Standby
+
+Aeron Cluster Standby is a premium feature.
+In order to the Standby quickstart you must have access to the binaries Aeron Cluster Standby provided by Adaptive.
+If you don't have access to these this feature interests you please contact adaptive via http://aeron.io.
+
+The Standby features of the quickstart a disabled by default.
+They need to be enabled in both the build and with any docker compose steps.
+E.g. for builds within the project root.
+
+```shell
+> ./gradlew -Pstandby=true
+```
+
+When running the docker steps within the `<project root>/docker` directory
+```shell
+> docker compose --profile standby build --no-cache
+> docker compose --profile standby up
+```

--- a/standby/setup-docker.sh
+++ b/standby/setup-docker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "debconf debconf/frontend select noninteractive" | debconf-set-selections
+
+apt-get update \
+    --quiet \
+    --assume-yes
+
+apt-get install \
+    --quiet \
+    --assume-yes \
+    --no-install-recommends \
+    bash \
+    procps \
+    less \
+    sysstat \
+    wget
+
+mkdir /root/aeron
+mkdir /root/jar
+
+wget https://repo1.maven.org/maven2/io/aeron/aeron-all/1.42.0/aeron-all-1.42.0.jar -P /root/aeron/
+# TODO: Copy cluster standby jars in place as well...

--- a/standby/src/main/java/io/aeron/samples/ClusterStandbyApp.java
+++ b/standby/src/main/java/io/aeron/samples/ClusterStandbyApp.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2023 Adaptive Financial Consulting
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aeron.samples;
+
+import io.aeron.archive.ArchivingMediaDriver;
+import io.aeron.cluster.ClusterBackup;
+import io.aeron.cluster.ClusterStandby;
+import io.aeron.cluster.service.ClusteredServiceContainer;
+import io.aeron.samples.cluster.ClusterConfig;
+import io.aeron.samples.infra.AppClusteredService;
+import org.agrona.concurrent.ShutdownSignalBarrier;
+import org.agrona.concurrent.SystemEpochClock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+
+import static io.aeron.samples.cluster.ClusterConfig.ARCHIVE_CONTROL_PORT_OFFSET;
+import static io.aeron.samples.cluster.ClusterConfig.MEMBER_FACING_PORT_OFFSET;
+import static java.lang.Integer.parseInt;
+
+/**
+ * Sample cluster backup application
+ */
+public class ClusterStandbyApp
+{
+    private static final Logger LOGGER = LoggerFactory.getLogger(ClusterStandbyApp.class);
+    public static final String DEFAULT_STANDBY_MEMBER_ID = "4";
+
+    /**
+     * The main method.
+     *
+     * @param args command line args
+     */
+    @SuppressWarnings("UnnecessaryLocalVariable")
+    public static void main(final String[] args)
+    {
+        final ShutdownSignalBarrier barrier = new ShutdownSignalBarrier();
+        final String standbyHost = getStandbyHost();
+        final int standbyMemberId = getMemberId();
+        final int basePort = getBasePort();
+        final String hosts = getClusterAddresses();
+        final List<String> hostAddresses = List.of(hosts.split(","));
+        final File baseDir = getBaseDir(standbyMemberId);
+
+        final ClusterConfig clusterConfig = ClusterConfig.create(
+            standbyMemberId, hostAddresses, hostAddresses, basePort, new AppClusteredService());
+        clusterConfig.baseDir(baseDir);
+
+        final String standbyConsensusEndpoint = standbyHost + ":" + ClusterConfig.calculatePort(
+            standbyMemberId, basePort, MEMBER_FACING_PORT_OFFSET);
+        final String standbyArchiveEndpoint = standbyHost + ":" + ClusterConfig.calculatePort(
+            standbyMemberId, basePort, ARCHIVE_CONTROL_PORT_OFFSET);
+        final String standbyResponseEndpoint = standbyHost + ":0";
+        final String clusterConsensusEndpoints = getClusterConsensusEndpoints();
+
+        clusterConfig.archiveContext().archiveDir(new File("standby/archive"));
+
+        // Context for Cluster Standby.
+        final ClusterStandby.Context clusterStandbyContext = new ClusterStandby.Context()
+            .clusterMemberId(standbyMemberId)                      // Mostly used to differentiate from other nodes in
+                                                                   // the cluster for logging.
+            .clusterConsensusEndpoints(clusterConsensusEndpoints)  // The endpoints of the primary cluster used for
+                                                                   // backup queries & sending snapshot notifications.
+            .standbyConsensusEndpoint(standbyConsensusEndpoint)    // Used for daisy-chained standbys to retrieve backup
+                                                                   // query responses.
+            .standbyArchiveEndpoint(standbyArchiveEndpoint)        // The endpoint for this standby's archive.
+            .responseEndpoint(standbyResponseEndpoint)             // The endpoint that receives responses to requests
+                                                                   // (e.g backup queries).
+            .standbyDir(new File(baseDir, "standby"))
+            .archiveContext(clusterConfig.aeronArchiveContext().clone())
+            .aeronDirectoryName(clusterConfig.mediaDriverContext().aeronDirectoryName())
+            .sourceType(ClusterBackup.SourceType.FOLLOWER) // What kind of node(s) to connect to.
+            .standbySnapshotEnabled(true)
+            .standbySnapshotNotificationsEnabled(true)
+            .deleteDirOnStart(true);
+
+        final ClusteredServiceContainer.Context clusteredServiceContext = clusterConfig.clusteredServiceContext();
+
+        LOGGER.info("Standby Directory: {} ", clusterStandbyContext.standbyDirectoryName());
+        LOGGER.info("Archive Directory: {} ", clusterConfig.archiveContext().archiveDir());
+        LOGGER.info("Connecting to cluster: {}", clusterConsensusEndpoints);
+
+        try (
+            ArchivingMediaDriver ignored = ArchivingMediaDriver.launch(
+                clusterConfig.mediaDriverContext(), clusterConfig.archiveContext());
+            ClusterStandby ignored1 = ClusterStandby.launch(clusterStandbyContext);
+            ClusteredServiceContainer ignored2 = ClusteredServiceContainer.launch(clusteredServiceContext))
+        {
+            LOGGER.info("Started Cluster Backup...");
+            barrier.await();
+            LOGGER.info("Exiting");
+        }
+    }
+
+    /**
+     * Get the cluster node id
+     * @return cluster node id, default 0
+     */
+    private static int getMemberId()
+    {
+        String memberId = System.getenv("CLUSTER_NODE");
+        if (null == memberId || memberId.isEmpty())
+        {
+            memberId = System.getProperty("node.id", DEFAULT_STANDBY_MEMBER_ID);
+        }
+        return parseInt(memberId);
+    }
+
+    private static String getClusterConsensusEndpoints()
+    {
+        final int portBase = getBasePort();
+        final String hosts = getClusterAddresses();
+        final String[] hostAddresses = hosts.split(",");
+        awaitDnsResolution(hostAddresses);
+        final StringJoiner endpointsBuilder = new StringJoiner(",");
+        for (int nodeId = 0; nodeId < hostAddresses.length; nodeId++)
+        {
+            final int port = ClusterConfig.calculatePort(nodeId, portBase, MEMBER_FACING_PORT_OFFSET);
+            endpointsBuilder.add(hostAddresses[nodeId] + ":" + port);
+        }
+        return endpointsBuilder.toString();
+    }
+
+    private static int getBasePort()
+    {
+        String portBaseString = System.getenv("CLUSTER_PORT_BASE");
+        if (null == portBaseString || portBaseString.isEmpty())
+        {
+            portBaseString = System.getProperty("port.base", "9000");
+        }
+        return parseInt(portBaseString);
+    }
+
+    /***
+     * Get the base directory for the cluster configuration
+     * @param nodeId node id
+     * @return base directory
+     */
+    private static File getBaseDir(final int nodeId)
+    {
+        final String baseDir = System.getenv("BASE_DIR");
+        if (null == baseDir || baseDir.isEmpty())
+        {
+            return new File(System.getProperty("user.dir"), "node" + nodeId);
+        }
+
+        return new File(baseDir);
+    }
+
+
+    private static String getClusterAddresses()
+    {
+        String clusterAddresses = System.getenv("CLUSTER_ADDRESSES");
+        if (null == clusterAddresses || clusterAddresses.isEmpty())
+        {
+            clusterAddresses = System.getProperty("cluster.addresses", "localhost");
+        }
+        return clusterAddresses;
+    }
+
+    private static String getStandbyHost()
+    {
+        final String backupHost = System.getenv("STANDBY_HOST");
+        if (backupHost == null || backupHost.isEmpty())
+        {
+            return "localhost";
+        }
+        awaitDnsResolution(backupHost);
+        return backupHost;
+    }
+
+    private static void awaitDnsResolution(final String[] hosts)
+    {
+        if (applyDnsDelay())
+        {
+            LOGGER.info("Waiting 5 seconds for DNS to be registered...");
+            quietSleep(5000);
+        }
+        java.security.Security.setProperty("networkaddress.cache.ttl", "0");
+
+        Arrays.stream(hosts).forEach(ClusterStandbyApp::awaitDnsResolution);
+    }
+
+    private static void awaitDnsResolution(final String host)
+    {
+        final long endTime = SystemEpochClock.INSTANCE.time() + 60000;
+        boolean resolved = false;
+        while (!resolved)
+        {
+            if (SystemEpochClock.INSTANCE.time() > endTime)
+            {
+                LOGGER.error("cannot resolve name {}, exiting", host);
+                System.exit(-1);
+            }
+
+            try
+            {
+                InetAddress.getByName(host);
+                resolved = true;
+            }
+            catch (final UnknownHostException e)
+            {
+                LOGGER.warn("cannot yet resolve name {}, retrying in 3 seconds", host);
+                quietSleep(3000);
+            }
+        }
+    }
+
+    /**
+     * Apply DNS delay
+     *
+     * @return true if DNS delay should be applied
+     */
+    private static boolean applyDnsDelay()
+    {
+        final String dnsDelay = System.getenv("DNS_DELAY");
+        if (null == dnsDelay || dnsDelay.isEmpty())
+        {
+            return false;
+        }
+        return Boolean.parseBoolean(dnsDelay);
+    }
+
+    /**
+     * Sleeps for the given number of milliseconds, ignoring any interrupts.
+     *
+     * @param millis the number of milliseconds to sleep.
+     */
+    private static void quietSleep(final long millis)
+    {
+        try
+        {
+            Thread.sleep(millis);
+        }
+        catch (final InterruptedException ex)
+        {
+            LOGGER.warn("Interrupted while sleeping");
+        }
+    }
+}

--- a/standby/src/main/resources/logback.xml
+++ b/standby/src/main/resources/logback.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2023 Adaptive Financial Consulting
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration debug="false">
+    <property name="LOG_PATTERN" value="%msg%n"/>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="${LOG_LEVEL:-info}">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Include optional support for Cluster Standby as part of quick start.
- Only include basic startup and deployment of a single standby.
- Disabled by default, see standby/readme.md for usage instructions.
- Only works if user has access to the standby premium feature.