### PR TITLE
PLAT-1235  Do not use aeron-all uber jar as a dependency.

### DIFF
--- a/admin/build.gradle.kts
+++ b/admin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 
 dependencies {
     implementation(libs.agrona)
-    implementation(libs.aeron)
+    implementation(libs.bundles.aeron)
     implementation(libs.slf4j)
     implementation(libs.logback)
     implementation(libs.picocli)

--- a/backup/build.gradle.kts
+++ b/backup/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
     implementation(libs.agrona)
-    implementation(libs.aeron)
+    implementation(libs.bundles.aeron)
     implementation(libs.slf4j)
     implementation(libs.logback)
     testImplementation(libs.bundles.testing)

--- a/cluster/build.gradle.kts
+++ b/cluster/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
     implementation(libs.agrona)
-    implementation(libs.aeron)
+    implementation(libs.bundles.aeron)
     implementation(libs.slf4j)
     implementation(libs.logback)
     implementation(project(":cluster-protocol"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,10 @@ slf4jVersion = "2.0.17"
 versions = "0.53.0"
 
 [libraries]
-aeron = { group = "io.aeron", name = "aeron-all", version.ref = "aeronVersion" }
+aeron-archive = { group = "io.aeron", name = "aeron-archive", version.ref = "aeronVersion" }
+aeron-client = { group = "io.aeron", name = "aeron-client", version.ref = "aeronVersion" }
+aeron-cluster = { group = "io.aeron", name = "aeron-cluster", version.ref = "aeronVersion" }
+aeron-samples = { group = "io.aeron", name = "aeron-samples", version.ref = "aeronVersion" }
 agrona = { group = "org.agrona", name = "agrona", version.ref = "agronaVersion" }
 sbe = { group = "uk.co.real-logic", name = "sbe-tool", version.ref = "sbeVersion" }
 jupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitVersion" }
@@ -33,6 +36,7 @@ junitPlatformLauncher = { group = "org.junit.platform", name = "junit-platform-l
 clusterStandby = { group = "io.aeron.premium.standby", name = "aeron-cluster-standby", version.ref = "aeronClusterStandbyVersion" }
 
 [bundles]
+aeron = ["aeron-archive", "aeron-client", "aeron-cluster", "aeron-samples"]
 testing = ["junitPlatformLauncher", "jupiterApi", "jupiterEngine", "mockito-core", "mockito-junit"]
 
 [plugins]

--- a/standby/build.gradle.kts
+++ b/standby/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 dependencies {
     implementation(libs.agrona)
-    implementation(libs.aeron)
+    implementation(libs.bundles.aeron)
     implementation(libs.clusterStandby)
     implementation(libs.slf4j)
     implementation(libs.logback)


### PR DESCRIPTION
Note that when split into actual modules, we didn't all that is in the uber jar.
This also allows specific modules finer control over what they depend on. (At the moment, I've just updated all to use the bundle, but perhaps some only need the archive or cluster dependency etc.).
Needless to say: Best practice is to depend only on what you actually need.
Second commit actually fixes the build which was broken... 
